### PR TITLE
Update content structure and add initial "State Management" section

### DIFF
--- a/website/docs/data-fetching-caching/overview.mdx
+++ b/website/docs/data-fetching-caching/overview.mdx
@@ -1,0 +1,6 @@
+---
+id: overview
+title: "Data Fetching and Caching: Overview"
+sidebar_label: "Data Fetching and Caching: Overview"
+---
+

--- a/website/docs/state-management/mobx.mdx
+++ b/website/docs/state-management/mobx.mdx
@@ -1,0 +1,25 @@
+---
+id: mobx
+title: "Mobx"
+sidebar_label: "Mobx"
+---
+
+## Description
+
+Mobx applies concepts from Functional Reactive Programming and Object-Oriented design to automatically track changes to state and propagate updates.  Mobx lets you create individual "store" classes and mark specific fields as "observable", then mark React components and other logic as "observers".  You can directly modify those observables fields in your code, and Mox will transparently update any observer code that depends on those fields.
+
+## Purpose and Use Cases
+
+TBD
+
+## Tradeoffs
+
+TBD
+
+
+## When Should I Consider Using This?
+
+TBD
+
+
+## Further Information

--- a/website/docs/state-management/overview.mdx
+++ b/website/docs/state-management/overview.mdx
@@ -1,0 +1,74 @@
+---
+id: overview
+title: "State Management: Overview"
+sidebar_label: "State Management: Overview"
+---
+
+## What is State Management?
+
+**"State" is any data that describes the current behavior of an application**.  This could include values like "a list of objects fetched from the server", "which item is currently selected", "name of the currently logged-in user", and "is this modal open?".
+
+**"State Management" is the process of dealing with changes to state over time**.  This means having ways to:
+
+- *store* an initial value
+- *read* the current value
+- *update* a value
+
+There's also typically a way to be notified when the current value has changed.
+
+React applications decide what UI to render based on the current state values.  Because of this, understanding when and how to use different techniques for managing state is a key skill for all React developers, as is the ability to decide where a given piece of state should live.
+
+
+
+## Types of State
+
+There's several ways we could categorize different kinds of state in a client-side application.  One set of categories might be:
+
+- **Data**: values that relate to specific features or business logic in the application (such as a list of todos)
+- **Control/UI state**: values related to how the user is interacting with the app (such as which todo item is currently selected)
+- **Session state**: values related to the current user (such as a username or profile)
+- **Communication state**: values that describe requests to other servers (such as a "loading" value)
+- **Location state**: values that are in the current browser URL and HTML `history` object (such as the domain, the path, query parameters, and client routing navigation history)
+
+Another set of categories might be:
+
+- **Local client state**: values that are scoped directly to a single component or its descendants
+- **Global client state**: values that are broadly needed in many places throughout an application
+- **Server state**: values that are fetched from a server via an API and cached on the client
+
+
+## State Management Tools
+
+Because state management is such a vital part of writing React applications, the React community has developed many different tools and patterns for working with state.  
+
+### React State Management
+
+React itself has several built-in APIs for managing state, including the `useState` and `useReducer` hooks for managing state inside of React components.  It also has a Context API to help with passing data down the component tree.  In many cases, React's built-in state management tools are all you'll need to build applications.
+
+Some common patterns for React state management are:
+
+- **"Lifting state up"**: since data flows down the tree as props, sibling components can't share data directly. By putting state in their nearest common ancestor component, the child components can all receive that data via props or context.
+- **"Colocating state"**: some state may only be needed in a certain subtree of the application.  It's best to keep the state stored as close as possible to where it's actually needed, which helps optimize rendering behavior.
+- **"Prop drilling"**: passing values from parents as props through many levels of nested child components, explicitly
+- **"Providers"**: React's Context API allows rendering a `<MyContext.Provider value={someValue}>` component, and nested children can read the value from that context directly without having to prop-drill. A component whose job is to store state and render a `<MyContext.Provider>` is also often referred to as a "provider component".
+
+### External State Management
+
+The React community has created many different libraries to help manage state outside of React components.  Some of the most popular libraries are:
+
+- [Redux](./redux.mdx): focuses on making state updates predictable and traceable, with inspiration from the "Flux Architecture" pattern and Functional Programming principles.  It relies on separating descriptions of "what happened", called "actions", from the logic that decides how state should be updated, called "reducer functions".  Redux centralizes global application state into a single "store", and provides browser DevTools to view the history of state changes over time.
+- [Mobx](./mobx.mdx): applies concepts from Functional Reactive Programming and Object-Oriented design to automatically track changes to state and propagate updates.  Mobx lets you create individual "store" classes and mark specific fields as "observable", then mark React components and other logic as "observers".  You can directly modify those observables fields in your code, and Mox will transparently update any observer code that depends on those fields.
+- [XState](./xstate.mdx): builds on time-tested Computer Science patterns for defining and executing Finite State Machines and Statecharts, including interacting between those machines using the Actor Model.  XState enables defining specific known possible states for a system, how different events cause transitions between those states, and what side effects are executed as a result. It has the ability to visualize state machines and their transitions graphically.
+
+
+## Data Fetching and Caching
+
+There is overlap between the ideas of "managing state" and "caching fetched data from the server".  For example, you can use a state management tool like Mobx or Redux to track loading state and cache the fetched data, although they are not purpose-built for that use case.  There are also tools that _are_ specifically designed to abstract the use case of fetching data, caching it, and managing the loading state and cached data internally without needing to write that code yourself.  
+
+See [Data Fetching and Caching: Overview](../data-fetching-caching/overview.mdx) for discussion of concepts and tools for that category.
+
+
+## Further Information
+
+- [The 5 Types of React Application State](http://jamesknelson.com/5-types-react-application-state/)
+

--- a/website/docs/state-management/react-state.mdx
+++ b/website/docs/state-management/react-state.mdx
@@ -1,0 +1,25 @@
+---
+id: react-state
+title: "React State"
+sidebar_label: "React State"
+---
+
+## Description
+
+React itself has several built-in APIs for managing state, including the `useState` and `useReducer` hooks for managing state inside of React components.  It also has a Context API to help with passing data down the component tree.  In many cases, React's built-in state management tools are all you'll need to build applications.
+
+## Purpose and Use Cases
+
+TBD
+
+## Tradeoffs
+
+TBD
+
+
+## When Should I Consider Using This?
+
+TBD
+
+
+## Further Information

--- a/website/docs/state-management/redux.mdx
+++ b/website/docs/state-management/redux.mdx
@@ -1,0 +1,25 @@
+---
+id: redux
+title: "Redux"
+sidebar_label: "Redux"
+---
+
+## Description
+
+Redux focuses on making state updates predictable and traceable, with inspiration from the "Flux Architecture" pattern and Functional Programming principles.  It relies on separating descriptions of "what happened", called "actions", from the logic that decides how state should be updated, called "reducer functions".  Redux centralizes global application state into a single "store", and provides browser DevTools to view the history of state changes over time.
+
+## Purpose and Use Cases
+
+TBD
+
+## Tradeoffs
+
+TBD
+
+
+## When Should I Consider Using This?
+
+TBD
+
+
+## Further Information

--- a/website/docs/state-management/redux.mdx
+++ b/website/docs/state-management/redux.mdx
@@ -6,20 +6,74 @@ sidebar_label: "Redux"
 
 ## Description
 
+**Redux is a pattern and library for managing and updating application state, using events called "actions"**. It serves as a centralized store for state that needs to be used across your entire application, with rules ensuring that the state can only be updated in a predictable fashion.
+
 Redux focuses on making state updates predictable and traceable, with inspiration from the "Flux Architecture" pattern and Functional Programming principles.  It relies on separating descriptions of "what happened", called "actions", from the logic that decides how state should be updated, called "reducer functions".  Redux centralizes global application state into a single "store", and provides browser DevTools to view the history of state changes over time.
 
 ## Purpose and Use Cases
 
-TBD
+**The primary purpose of Redux is to help you manage "global" state** - state that is needed across many parts of your application.
+
+**The patterns and tools provided by Redux make it easier to understand when, where, why, and how the state in your application is being updated, and how your application logic will behave when those changes occur**. Redux guides you towards writing code that is predictable and testable, which helps give you confidence that your application will work as expected.
+
+Because any component can access data that is being kept in the Redux store, it _can_ be used to avoid "prop-drilling".  However, this is an added benefit, and not specifically the main reason to use Redux.
+
+
 
 ## Tradeoffs
 
-TBD
+Redux asks you to write your code following specific patterns:
+
+- Application state should be described using plain JS objects and arrays
+- There must be a single Redux store that holds the application state
+- The store can only be updated by describing events that happen as plain "action" objects, and "dispatching" them to the store for processing
+- The logic for updating the store state must be written as "reducer" functions, which look at the current state and the action object to decide what the resulting new state should be.  Reducer functions must be "pure", with no side effects, and must calculate the new state using immutable updates.
+
+This adds a level of indirection to the process of managing state. Because of this, Redux is not intended to be the shortest or fastest way to update state.  
+
+However, the indirection of separating descriptions of "what happened" from the logic that determines "how the state should be updated" allows Redux to track how the state changed every time an action is dispatched.  The Redux DevTools can then display the history of dispatched actions, the diff between states, and the complete state tree after each dispatched action. This makes it easier to understand how the application behaves as things change.  This also enables Redux "middleware", which can inspect dispatched actions and run additional logic in response.
+
+Because Redux is a single store, all components that have subscribed to reading state updates have to re-run comparison checks after every dispatched action, to see if the data needed by that specific component has changed.  This does require that users carefully define how each component reads data from the Redux store, including use of "memoized" selector functions and semi-manual optimizations.  It also means that it's generally not a good idea to put most UI state values like "is this dropdown open?" or form state into the Redux store.
+
+Redux is UI-agnostic and can be used with any UI layer, including React, Angular, Vue, and vanilla JS.
+
+## Packages
+
+The core [Redux](https://redux.js.org/) library provides a minimal set of APIs for creating a Redux store.  
+
+The official [Redux Toolkit](https://redux-toolkit.js.org) package adds additional APIs for standard Redux use cases like setting up a store with good defaults, catching common mistakes in development, and creating Redux reducers with simpler logic than writing immutable updates by hand.
+
+[React-Redux](https://react-redux.js.org) is the official bindings layer that lets React components interact with a Redux store by reading state values and dispatching actions.
+
+Redux has a thriving ecosystem of additional addons, including middleware for writing side effects and async logic with different syntaxes, tools for persisting store state, and much more.
 
 
 ## When Should I Consider Using This?
 
-TBD
+Redux helps you deal with shared state management, but there are more concepts to learn, and more code to write. It also adds some indirection to your code, and asks you to follow certain restrictions. It's a trade-off between short term and long term productivity.
+
+**Redux is more useful when**:
+
+- You have large amounts of application state that are needed in many places in the app
+- The app state is updated semi-frequently
+- The logic to update that state may be complex
+- The app has a medium or large-sized codebase, and might be worked on by many people
+- You want to see a history of changes to your application state over time
+- You want to write as much of your logic as possible separate from the UI layer
+
+**You should probably avoid using Redux if**:
+
+- You prefer an Object-Oriented approach instead of a Functional Programming approach
+- Your app mostly depends on fetching and caching data from the server and you are using another tool to manage that cached server state
+- You want UI updates and data dependencies to be as automatic as possible, with minimal manual optimizations
+- You prefer writing logic that directly applies state updates with minimal indirection
+- Most of the data in your application is only needed by specific subsections of the component tree, with little "global" state
+- You want to stick with built-in React APIs and avoid additional third-party dependencies
 
 
 ## Further Information
+
+- [When (and when not) to reach for Redux](https://changelog.com/posts/when-and-when-not-to-reach-for-redux)
+- [The Tao of Redux, Part 1 - Implementation and Intent](https://blog.isquaredsoftware.com/2017/05/idiomatic-redux-tao-of-redux-part-1/)
+- [Redux FAQ: When should I use Redux?](https://redux.js.org/faq/general#when-should-i-use-redux)
+- [You Might Not Need Redux](https://medium.com/@dan_abramov/you-might-not-need-redux-be46360cf367)

--- a/website/docs/state-management/state-management.md
+++ b/website/docs/state-management/state-management.md
@@ -1,6 +1,0 @@
----
-id: state-management
-title: State Management
-sidebar_label: State Management
----
-

--- a/website/docs/state-management/xstate.mdx
+++ b/website/docs/state-management/xstate.mdx
@@ -1,0 +1,25 @@
+---
+id: xstate
+title: "XState"
+sidebar_label: "XState"
+---
+
+## Description
+
+XState builds on time-tested Computer Science patterns for defining and executing Finite State Machines and Statecharts, including interacting between those machines using the Actor Model.  XState enables defining specific known possible states for a system, how different events cause transitions between those states, and what side effects are executed as a result. It has the ability to visualize state machines and their transitions graphically.
+
+## Purpose and Use Cases
+
+TBD
+
+## Tradeoffs
+
+TBD
+
+
+## When Should I Consider Using This?
+
+TBD
+
+
+## Further Information

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -97,7 +97,7 @@ module.exports = {
                     path: "./docs",
                     routeBasePath: "/",
                     include: [
-                        "{common-mistakes,glossary,how-to,state-management,use-cases}/*.{md,mdx}",
+                        "**/*.{md,mdx}",
                     ],
                     sidebarPath: require.resolve("./sidebars.js"),
                 },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -29,11 +29,10 @@ module.exports = {
                     position: "right",
                 },
                 {
-                    to: "/state-management/state-management",
+                    to: "/state-management/overview",
                     label: "State Management",
                     position: "right",
-                },
-                { to: "/how-to/how-to", label: "How To..", position: "right" },
+                }
             ],
         },
         footer: {
@@ -57,7 +56,7 @@ module.exports = {
                         },
                         {
                             label: "State Management",
-                            to: "/state-management/state-management",
+                            to: "/state-management/overview",
                         },
                         {
                             label: "How To",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,21 +1,13 @@
 module.exports = {
-    CommonMistakes: {
-        CommonMistakes: ["common-mistakes/mistake1"],
-    },
-    Glossary: {
+    docs: {
+        "Common Mistakes": ["common-mistakes/mistake1"],
         Glossary: ["glossary/glossary"],
-    },
-    HowTo: {
-        HowTo: ["how-to/how-to"],
-    },
-    StateManagement: {
-        StateManagement: ["state-management/state-management"],
-    },
-    UseCases: {
-        UseCases: [
+        "How To": ["how-to/how-to"],
+        "State Management": ["state-management/state-management"],
+        "Use Cases": [
             "use-cases/choosing-library-for-existing-project",
             "use-cases/starting-a-new-project",
             "use-cases/starting-with-react",
         ],
-    },
+    }
 };

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -3,7 +3,14 @@ module.exports = {
         "Common Mistakes": ["common-mistakes/mistake1"],
         Glossary: ["glossary/glossary"],
         "How To": ["how-to/how-to"],
-        "State Management": ["state-management/state-management"],
+        "State Management": [
+            "state-management/overview",
+            "state-management/react-state",
+            "state-management/redux",
+            "state-management/mobx",
+            "state-management/xstate",
+        ],
+        "Data Fetching and Caching": ["data-fetching-caching/overview"],
         "Use Cases": [
             "use-cases/choosing-library-for-existing-project",
             "use-cases/starting-a-new-project",


### PR DESCRIPTION
This PR:

- Consolidates the Docusaurus sidebar setup into a single sidebar entry
- Adds a "State Management Overview" page that summarizes what this is and some of the major ideas/tools
- Adds skeleton pages for React state, Mobx, and XState
- Adds a page describing the purposes and use cases for Redux